### PR TITLE
Remove local item from .gitignore. Should be in a global gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 target
-*.swp


### PR DESCRIPTION
Hey David,

Thanks for the tip. I made a `.gitignore_global` and I can now remove the `*.swp` line from the projects' `.gitignore`. It is indeed cleaner to keep local stuff local. 